### PR TITLE
Fix MusicPlayer missing play method

### DIFF
--- a/backend/app/models/player.py
+++ b/backend/app/models/player.py
@@ -23,6 +23,11 @@ class MusicPlayer:
         self.player.set_media(self.media)
         self.current_track = file_path
 
+    def play(self, file_path: str):
+        """Convenience method to load a track and start playback."""
+        self.load_music(file_path)
+        self.start()
+
     def start(self):
         self.player.play()
 


### PR DESCRIPTION
## Summary
- add `play()` method to `MusicPlayer` to load a track and start playback

## Testing
- `pytest backend/tests/test_player.py -q` *(fails: fixture 'file_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602a5d11b0833381f6179569d3782e