### PR TITLE
Add basic material design UI skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+
+# Node/Electron
+node_modules/
+/dist/
+
+# Environment
+venv/
+.env

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 flask==2.2.3
 flask-cors==3.0.10
 flask-socketio==5.3.3
-python-vlc==3.0.18120
+python-vlc==3.0.18122
 mutagen==1.46.0
 sqlalchemy==2.0.7
 pytest==7.3.1

--- a/docs/Frontend-UI.md
+++ b/docs/Frontend-UI.md
@@ -1,0 +1,15 @@
+# Frontend UI Overview
+
+The Acoustic Player frontend aims to provide a simple, elegant experience based
+on Material Design principles. The current implementation is a minimal web page
+using Materialize CSS. It serves as a starting point for an eventual Electron
+interface.
+
+## Features
+
+- Materialize CSS for modern styling
+- Fetches track data from the Flask backend
+- Click a track to start playback via the REST API
+
+Future iterations can expand this into a full Electron application with richer
+components and animations.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,23 @@
+# Acoustic Player Frontend
+
+This folder contains the web-based UI for Acoustic Player. The interface uses
+[Materialize CSS](https://materializecss.com/) to provide a clean, material design
+style and communicates with the Flask backend through the `api.js` module.
+
+## Running
+
+1. Start the backend server:
+   ```bash
+   cd ../backend
+   python main.py
+   ```
+2. Open `index.html` in a browser or load it inside an Electron renderer process.
+
+The page will request the track list from the backend and display it. Clicking a
+track will start playback using the backend player API.
+
+## Files
+
+- `index.html` – basic layout with Material design components
+- `style.css` – custom styles
+- `main.js` – loads tracks and wires up simple playback actions

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Acoustic Player</title>
+    <!-- Materialize CSS via CDN -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+</head>
+<body class="grey lighten-4">
+    <nav class="blue-grey darken-3">
+        <div class="nav-wrapper container">
+            <a href="#" class="brand-logo">Acoustic Player</a>
+        </div>
+    </nav>
+
+    <div class="container" id="content">
+        <div class="section" id="library-section">
+            <h5>Library</h5>
+            <ul id="track-list" class="collection"></ul>
+        </div>
+    </div>
+
+    <!-- Materialize JS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script type="module" src="js/api.js"></script>
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,24 @@
+import { initApi } from './js/api.js';
+
+const { libraryApi, playerApi } = initApi();
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadLibrary();
+});
+
+async function loadLibrary() {
+    try {
+        const tracks = await libraryApi.getTracks();
+        const list = document.getElementById('track-list');
+        list.innerHTML = '';
+        tracks.forEach(track => {
+            const li = document.createElement('li');
+            li.className = 'collection-item';
+            li.textContent = `${track.artist} - ${track.title}`;
+            li.addEventListener('click', () => playerApi.play(track.path));
+            list.appendChild(li);
+        });
+    } catch (err) {
+        console.error('Failed to load tracks', err);
+    }
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,6 @@
+body {
+    font-family: 'Roboto', sans-serif;
+}
+#track-list li {
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- switch invalid python-vlc version to 3.0.18122
- create `.gitignore`
- add minimal Materialize-based UI (`index.html`, `main.js`, `style.css`)
- document frontend usage in new README and UI overview doc

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68602c77ab308333b25e68ff4f92ef26