### PR TITLE
Port old frontend to new React shell

### DIFF
--- a/acoustic_player/README.md
+++ b/acoustic_player/README.md
@@ -52,3 +52,13 @@ export default tseslint.config({
   },
 })
 ```
+
+## Development
+
+This frontend expects the Flask backend to run on `http://localhost:5000`. You can adjust the API URL by editing `.env`:
+
+```bash
+VITE_API_BASE_URL=http://localhost:5000/api
+```
+
+Start the backend from the `backend` folder with `python main.py` and then run `npm run dev` here to launch the Electron shell.

--- a/acoustic_player/index.html
+++ b/acoustic_player/index.html
@@ -4,10 +4,18 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Acoustic Player</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <link href="/src/ui/style.css" rel="stylesheet" />
   </head>
-  <body>
-    <div id="root"></div>
+  <body class="grey lighten-4">
+    <nav class="blue-grey darken-3">
+      <div class="nav-wrapper container">
+        <a href="#" class="brand-logo">Acoustic Player</a>
+      </div>
+    </nav>
+    <div id="root" class="container"></div>
     <script type="module" src="/src/ui/main.tsx"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
   </body>
 </html>

--- a/acoustic_player/src/electron/main.ts
+++ b/acoustic_player/src/electron/main.ts
@@ -1,8 +1,6 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow } from 'electron';
 import path from 'path';
 import { isDev } from './utils.js';
-
-type test = String;
 
 app.on('ready', () => {
     const mainWindow = new BrowserWindow({

--- a/acoustic_player/src/ui/api.ts
+++ b/acoustic_player/src/ui/api.ts
@@ -1,0 +1,34 @@
+// Minimal API client for the React frontend
+export interface Track {
+  id: number;
+  title: string;
+  artist: string;
+  path: string;
+}
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5000/api';
+
+export async function getTracks(): Promise<Track[]> {
+  const res = await fetch(`${API_BASE_URL}/library/tracks`);
+  if (!res.ok) throw new Error('Failed to get library tracks');
+  return res.json();
+}
+
+export async function scanDirectory(path: string): Promise<void> {
+  const res = await fetch(`${API_BASE_URL}/library/scan`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path })
+  });
+  if (!res.ok) throw new Error('Failed to scan directory');
+}
+
+export async function playTrack(trackPath: string): Promise<void> {
+  const res = await fetch(`${API_BASE_URL}/player/play`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path: trackPath })
+  });
+  if (!res.ok) throw new Error('Failed to play track');
+}

--- a/acoustic_player/src/ui/main.tsx
+++ b/acoustic_player/src/ui/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './style.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/acoustic_player/src/ui/style.css
+++ b/acoustic_player/src/ui/style.css
@@ -1,0 +1,7 @@
+body {
+  font-family: 'Roboto', sans-serif;
+}
+
+#track-list li {
+  cursor: pointer;
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ This module serves as the entry point for the Flask API server.
 """
 from flask import Flask, jsonify
 from flask_cors import CORS
-import os
+from config import settings
 from app.api import player_api, library_api, playlist_api, lyrics_api
 from app.ws import socketio
 from app.models.database import init_db, close_db_session
@@ -49,8 +49,11 @@ def create_app():
 
 if __name__ == '__main__':
     app = create_app()
-    # Get port from environment variable or use default
-    port = int(os.environ.get('PORT', 5000))
-    
-    # Run the app with Socket.IO
-    socketio.run(app, host='0.0.0.0', port=port, debug=True)
+
+    # Run the app with Socket.IO using configured host and port
+    socketio.run(
+        app,
+        host=settings.HOST,
+        port=settings.PORT,
+        debug=settings.DEBUG,
+    )


### PR DESCRIPTION
## Summary
- integrate old frontend with new `acoustic_player` React app
- add Materialize CSS and app shell in `index.html`
- implement minimal API client for backend requests
- create React UI that mirrors the original functionality
- include simple styles and fix Electron lint issues
- use config constants for backend port
- read API base URL from `.env`

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860563a5fa483338a1ba54a88e1ae7c